### PR TITLE
Enable WIFI_LoRa_32_V3 macro

### DIFF
--- a/boards/heltec_wifi_kit_32_V3.json
+++ b/boards/heltec_wifi_kit_32_V3.json
@@ -6,7 +6,7 @@
     },
     "core": "esp32",
     "extra_flags": [
-      "-DARDUINO_HELTEC_WIFI_Kit_32_V3"
+      "-DARDUINO_HELTEC_WIFI_Kit_32_V3 -DWIFI_LoRa_32_V3"
     ],
     "f_cpu": "240000000L",
     "f_flash": "80000000L",


### PR DESCRIPTION
The LoRaWAN library needs this one. 
![image](https://user-images.githubusercontent.com/26485477/214586238-1eb82378-7ea8-4b55-a57e-8dbfe8cd676d.png)
